### PR TITLE
VLM推論の並行パイプラインを実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -361,3 +361,5 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+
+.vscode/

--- a/JoyPredictor.cs
+++ b/JoyPredictor.cs
@@ -1,5 +1,4 @@
 using System;
-using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
@@ -212,31 +211,34 @@ namespace tagmane
                 return false;
             }
         }
-        
-        public (string, Dictionary<string, float>, Dictionary<string, float>, Dictionary<string, float>) Predict(
-            BitmapImage image,
-            float generalThresh)
+
+        public DenseTensor<float>? PrepareTensor(BitmapImage image)
         {
             if (!_isModelLoaded)
             {
-                // throw new InvalidOperationException("モデルが読み込まれていません。Predictを実行する前にLoadModelを呼び出してください。");
                 AddLogEntry("モデルが読み込まれていません。Predictを実行する前にLoadModelを呼び出してください。");
-                return ("", new Dictionary<string, float>(), new Dictionary<string, float>(), new Dictionary<string, float>());
+                throw new InvalidOperationException("モデルが読み込まれていません。Predictを実行する前にLoadModelを呼び出してください。");
             }
-
-            AddLogEntry("推論を開始します");
-            AddLogEntry($"generalThresh: {generalThresh}");
 
             DenseTensor<float> inputTensor;
             try
             {
-                inputTensor = PrepareImage(image);
+                inputTensor = InnerPrepareTensor(image);
             }
             catch (Exception ex)
             {
                 AddLogEntry($"画像の準備中にエラーが発生しました: {ex.Message}");
-                return ("", new Dictionary<string, float>(), new Dictionary<string, float>(), new Dictionary<string, float>());
+                return null;
             }
+            return inputTensor;
+        }
+        
+        public (string, Dictionary<string, float>, Dictionary<string, float>, Dictionary<string, float>) Predict(
+            DenseTensor<float> inputTensor,
+            float generalThresh)
+        {
+            AddLogEntry("推論を開始します");
+            AddLogEntry($"generalThresh: {generalThresh}");
 
             var inputs = new List<NamedOnnxValue> { NamedOnnxValue.CreateFromTensor("input", inputTensor) };
 
@@ -264,7 +266,7 @@ namespace tagmane
             }
         }
 
-        private DenseTensor<float> PrepareImage(BitmapImage image)
+        private DenseTensor<float> InnerPrepareTensor(BitmapImage image)
         {
             AddLogEntry("画像を準備しています");
             var tensor = new DenseTensor<float>(new[] { 1, 3, ImageSize, ImageSize });

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -145,10 +145,10 @@
                         <CheckBox x:Name="UseGPUCheckBox" Content="GPUを使用して推論する" IsChecked="True" Checked="UseGPUCheckBox_Checked" Unchecked="UseGPUCheckBox_Checked"/>
                     </StackPanel>
                     <StackPanel Orientation="Horizontal" Margin="0,5">
-                        <TextBlock Text="Batch Count:" VerticalAlignment="Center" Margin="0,0,5,0"/>
-                        <Slider x:Name="BatchCountSlider" Width="150" Minimum="1" Maximum="256" Value="4" 
+                        <TextBlock Text="VLM Concurrency:" VerticalAlignment="Center" Margin="0,0,5,0"/>
+                        <Slider x:Name="VLMConcurrencySlider" Width="100" Minimum="1" Maximum="64" Value="14" 
                                 TickFrequency="1" IsSnapToTickEnabled="True"/>
-                        <TextBlock x:Name="BatchCountValue" Text="{Binding ElementName=BatchCountSlider, Path=Value, StringFormat={}{0:F0}}" 
+                        <TextBlock x:Name="VLMConcurrencyValue" Text="{Binding ElementName=VLMConcurrencySlider, Path=Value, StringFormat={}{0:F0}}" 
                                    VerticalAlignment="Center" Margin="5,0,0,0"/>
                     </StackPanel>
                     <StackPanel Orientation="Horizontal" Margin="0,5">

--- a/RingBuffer.cs
+++ b/RingBuffer.cs
@@ -1,0 +1,79 @@
+using System.Collections.Generic;
+using System.Threading;
+
+public class RingBuffer<T>
+{
+    private readonly T[] _buffer;
+    private int _head;
+    private int _tail;
+    private int _count;
+    private readonly ReaderWriterLockSlim _lock = new ReaderWriterLockSlim();
+
+    public RingBuffer(int capacity)
+    {
+        _buffer = new T[capacity];
+        _head = 0;
+        _tail = 0;
+        _count = 0;
+    }
+
+    public void Enqueue(T item)
+    {
+        _lock.EnterWriteLock();
+        try
+        {
+            _buffer[_tail] = item;
+            _tail = (_tail + 1) % _buffer.Length;
+
+            if (_count == _buffer.Length)
+            {
+                _head = (_head + 1) % _buffer.Length;
+            }
+            else
+            {
+                _count++;
+            }
+        }
+        finally
+        {
+            _lock.ExitWriteLock();
+        }
+    }
+
+    public List<T> GetRecentItems()
+    {
+        _lock.EnterReadLock();
+        try
+        {
+            T[] snapshot = new T[_count];
+            for (int i = 0; i < _count; i++)
+            {
+                int index = (_head + i) % _buffer.Length;
+                snapshot[i] = _buffer[index];
+            }
+            return new List<T>(snapshot);
+        }
+        finally
+        {
+            _lock.ExitReadLock();
+        }
+    }
+
+    public int Count
+    {
+        get
+        {
+            _lock.EnterReadLock();
+            try
+            {
+                return _count;
+            }
+            finally
+            {
+                _lock.ExitReadLock();
+            }
+        }
+    }
+
+    public int Capacity => _buffer.Length;
+}

--- a/VLMPredictor.cs
+++ b/VLMPredictor.cs
@@ -1,17 +1,8 @@
-using Microsoft.ML.OnnxRuntime;
 using Microsoft.ML.OnnxRuntime.Tensors;
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.IO;
-using System.Linq;
-using System.Net.Http;
 using System.Threading.Tasks;
-using System.Windows;
 using System.Windows.Media.Imaging;
-using System.Security.Cryptography;
-using System.Drawing;
-using System.Drawing.Imaging;
 
 namespace tagmane
 {
@@ -62,9 +53,34 @@ namespace tagmane
             }
 
             if (_currentPredictor is WDPredictor wdPredictor)
-                return wdPredictor.Predict(image, generalThresh, generalMcutEnabled, characterThresh, characterMcutEnabled);
+                return wdPredictor.Predict(PrepareTensor(image)!, generalThresh, generalMcutEnabled, characterThresh, characterMcutEnabled);
             else if (_currentPredictor is JoyPredictor joyPredictor)
-                return joyPredictor.Predict(image, generalThresh);
+                return joyPredictor.Predict(PrepareTensor(image)!, generalThresh);
+            else
+                throw new InvalidOperationException("No predictor loaded");
+        }
+
+        public DenseTensor<float>? PrepareTensor(BitmapImage image)
+        {
+            if (_currentPredictor is WDPredictor wdPredictor)
+                return wdPredictor.PrepareTensor(image);
+            else if (_currentPredictor is JoyPredictor joyPredictor)
+                return joyPredictor.PrepareTensor(image);
+            else
+                throw new InvalidOperationException("No predictor loaded");
+        }
+
+        public (string, Dictionary<string, float>, Dictionary<string, float>, Dictionary<string, float>) Predict(
+            DenseTensor<float> tensor, 
+            float generalThresh,
+            bool generalMcutEnabled,
+            float characterThresh,
+            bool characterMcutEnabled)
+        {
+            if (_currentPredictor is WDPredictor wdPredictor)
+                return wdPredictor.Predict(tensor, generalThresh, generalMcutEnabled, characterThresh, characterMcutEnabled);
+            else if (_currentPredictor is JoyPredictor joyPredictor)
+                return joyPredictor.Predict(tensor, generalThresh);
             else
                 throw new InvalidOperationException("No predictor loaded");
         }

--- a/WDPredictor.cs
+++ b/WDPredictor.cs
@@ -254,7 +254,7 @@ namespace tagmane
             }
         }
         public (string, Dictionary<string, float>, Dictionary<string, float>, Dictionary<string, float>) Predict(
-            BitmapImage image,
+            DenseTensor<float> inputTensor,
             float generalThresh,
             bool generalMcutEnabled,
             float characterThresh,
@@ -272,7 +272,6 @@ namespace tagmane
             // AddLogEntry($"characterThresh: {characterThresh}");
             // AddLogEntry($"characterMcutEnabled: {characterMcutEnabled}");
 
-            var inputTensor = PrepareImage(image);
             var inputs = new List<NamedOnnxValue> { NamedOnnxValue.CreateFromTensor(_model.InputMetadata.First().Key, inputTensor) };
 
             using (var outputs = _model.Run(inputs))
@@ -288,8 +287,9 @@ namespace tagmane
 
                 return (sortedGeneralStrings, rating, characters, general);
             }
-    }
-        private DenseTensor<float> PrepareImage(BitmapImage image)
+        }
+
+        public DenseTensor<float> PrepareTensor(BitmapImage image)
         {
             var tensor = new DenseTensor<float>(new[] { 1, _modelTargetSize, _modelTargetSize, 3 });
 

--- a/tagmane.csproj
+++ b/tagmane.csproj
@@ -128,6 +128,8 @@
     <PackageReference Include="Microsoft.ML.OnnxRuntime.Gpu" Version="1.18.1" />
     <PackageReference Include="UMAP" Version="1.0.34015" />
     <PackageReference Include="WindowsAPICodePackShell" Version="8.0.6" />
+    <PackageReference Include="R3" Version="1.2.9" />
+    <PackageReference Include="System.Reactive" Version="6.0.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
* LoadImageでロード時にメモリにキャッシュしないようにし、画像のロード速度UP
* LoadImageのGCを削除し、ランタイムのGCに任せるようにし、ImageSelectionでドラッグ操作して連続的に画像をロードするときの反応速度UP
* RingBuffer を導入し、UI Log の更新処理を軽量化
* Batch処理をConcurrency制御と並行パイプラインに置き換え
* 排他制御で並列上限までのタスクの並列実行をサポートするパイプラインを実装、CPUの利用効率を上げた
* AllTagViewのアップデートを定期更新にし、大量のUI更新を避けつつも、VLM推論中であっても高頻度で最新のタグ状況をレポートするようにした
* UpdateAllTagsで選択を変化させないようなアクションで選択を更新しないオプションを用意して、超細かくUIスレッド時間を節約