### PR TITLE
AsyncPipelineの初期化処理を修正 + GPU並列度のコードを微修正（若干速くなります）

### DIFF
--- a/Services/AsyncPipelineService.cs
+++ b/Services/AsyncPipelineService.cs
@@ -79,6 +79,8 @@ public class AsyncPipelineService
 
         lock (_concurrencyLock)
         {
+            _lastAdjustmentTime = DateTime.Now;
+
             var newLimit = _currentGpuConcurrencyLimit;
             
             // 調整ロジックをより慎重に
@@ -102,7 +104,6 @@ public class AsyncPipelineService
             if (newLimit != _currentGpuConcurrencyLimit)
             {
                 _currentGpuConcurrencyLimit = newLimit;
-                _lastAdjustmentTime = DateTime.Now;
             }
         }
     }

--- a/Utils/RingBuffer.cs
+++ b/Utils/RingBuffer.cs
@@ -1,7 +1,8 @@
+using System.Collections;
 using System.Collections.Generic;
 using System.Threading;
 
-public class RingBuffer<T>
+public class RingBuffer<T> : IEnumerable<T>
 {
     private readonly T[] _buffer;
     private int _head;
@@ -76,4 +77,26 @@ public class RingBuffer<T>
     }
 
     public int Capacity => _buffer.Length;
+    
+    public IEnumerator<T> GetEnumerator()
+    {
+        _lock.EnterReadLock();
+        try
+        {
+            for (int i = 0; i < _count; i++)
+            {
+                int index = (_head + i) % _buffer.Length;
+                yield return _buffer[index];
+            }
+        }
+        finally
+        {
+            _lock.ExitReadLock();
+        }
+    }
+
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        return GetEnumerator();
+    }
 }


### PR DESCRIPTION
<img width="1079" alt="スクリーンショット 2024-11-04 233457" src="https://github.com/user-attachments/assets/b2192273-67dd-4720-aaed-46594006078b">

初回のVLM推論が初期化で落ちる問題の修正です